### PR TITLE
edit box should now be working

### DIFF
--- a/lib/controllers/live_entry_controller.dart
+++ b/lib/controllers/live_entry_controller.dart
@@ -201,4 +201,55 @@ class LiveEntryController extends ChangeNotifier {
     // Save updated list
     _prefs.rawTimes = jsonEncode(list);
   }
+
+  void editLastEntry(String newBib, DateTime newDateTime, bool newIsContinuing, bool newHasPacer) {
+    final storedJson = _prefs.rawTimes;
+    if (storedJson == null) return;
+    List<dynamic> list = jsonDecode(storedJson);
+    if (list.isEmpty) return;
+
+    // Find the last entry (assuming it's the last one)
+    var lastEntry = list.last;
+    if (lastEntry['attributes'] != null) {
+      lastEntry['attributes']['bib_number'] = newBib;
+      lastEntry['attributes']['entered_time'] = TimeUtils.formatEnteredTimeLocal(newDateTime);
+      lastEntry['attributes']['stopped_here'] = (!newIsContinuing).toString();
+      lastEntry['attributes']['with_pacer'] = newHasPacer.toString();
+    }
+
+    // Save updated list
+    _prefs.rawTimes = jsonEncode(list);
+
+    // Also update RawTimeStore
+    RawTimeStore.editLast(RawTimeEntry(
+      eventSlug: _eventSlug,
+      splitName: _aidStation,
+      bibNumber: int.parse(newBib),
+      subSplitKind: lastEntry['attributes']['sub_split_kind'] ?? 'in',
+      stoppedHere: !newIsContinuing,
+      enteredTime: TimeUtils.formatEnteredTimeLocal(newDateTime),
+    ));
+
+    // Update controller state
+    updateBibNumber(newBib);
+    _entryTime = newDateTime;
+    toggleIsContinuing(newIsContinuing);
+    toggleHasPacer(newHasPacer);
+    updateAthleteInfo();
+  }
+
+  void deleteLastEntry() {
+    final storedJson = _prefs.rawTimes;
+    if (storedJson == null) return;
+    List<dynamic> list = jsonDecode(storedJson);
+    if (list.isEmpty) return;
+
+    list.removeLast();
+
+    // Save updated list
+    _prefs.rawTimes = jsonEncode(list);
+
+    // Also remove from RawTimeStore
+    RawTimeStore.removeLast(_eventSlug);
+  }
 }

--- a/lib/pages/live_entry.dart
+++ b/lib/pages/live_entry.dart
@@ -33,6 +33,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
 
   bool _isStationPressed = false;
   bool _isLoading = true;
+  String _lastBib = '';
 
   void _showEditSheet() {
     // Format date and time separately
@@ -46,8 +47,9 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
       isScrollControlled: true, // Allows sheet to grow if needed
       builder: (context) {
         return EditEntryBottomSheet(
+          controller: _controller,
           eventName: _controller.eventName,
-          bibNumber: _controller.bibNumber,
+          bibNumber: _lastBib,
           athleteName: _controller.athleteName,
           date: dateStr,
           time: timeStr,
@@ -62,6 +64,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
   void initState() {
     super.initState();
     _focusNode.requestFocus();
+    _controller.addListener(() => setState(() {}));
     // We can't access widget.parameters in initState, so we'll load data in didChangeDependencies
   }
 
@@ -76,6 +79,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
   void dispose() {
     LiveEntryScreen.routeObserver.unsubscribe(this);
     _focusNode.dispose();
+    _controller.removeListener(() => setState(() {}));
     super.dispose();
   }
 
@@ -116,6 +120,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
             child: ElevatedButton(
               onPressed: () {
                 setState(() {
+                  _lastBib = _controller.bibNumber;
                   _controller.stationControl('out', _prefs.deviceID);
                   _isStationPressed = true;
                   _controller.updateBibNumber('');
@@ -134,6 +139,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
             child: ElevatedButton(
               onPressed: () {
                 setState(() {
+                  _lastBib = _controller.bibNumber;
                   _controller.stationControl('in', _prefs.deviceID);
                   _isStationPressed = true;
                   _controller.updateBibNumber('');
@@ -152,6 +158,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
             child: ElevatedButton(
               onPressed: () {
                 setState(() {
+                  _lastBib = _controller.bibNumber;
                   _controller.stationControl('in', _prefs.deviceID);
                   _isStationPressed = true;
                   _controller.updateBibNumber('');
@@ -164,6 +171,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
             child: ElevatedButton(
               onPressed: () {
                 setState(() {
+                  _lastBib = _controller.bibNumber;
                   _controller.stationControl('out', _prefs.deviceID);
                   _isStationPressed = true;
                   _controller.updateBibNumber('');
@@ -184,6 +192,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
       onKey: (RawKeyEvent event) {
         if (event is RawKeyDownEvent && event.logicalKey == LogicalKeyboardKey.enter) {
           setState(() {
+            _lastBib = _controller.bibNumber;
             if (_controller.aidStation == "Finish") {
               _controller.stationControl('in', _prefs.deviceID);
             } else {
@@ -248,7 +257,7 @@ class _LiveEntryScreenState extends State<LiveEntryScreen> with RouteAware {
                               isStationPressed: _isStationPressed,
                               atheleteOrigin: _controller.athleteOrigin,
                               showEditSheet: _showEditSheet,
-                              lastBib: _controller.bibNumber,
+                              lastBib: _lastBib,
                               lastEntryTime: _controller.entryTime,
                             ),
                           ],

--- a/lib/services/crosscheck/raw_time_store.dart
+++ b/lib/services/crosscheck/raw_time_store.dart
@@ -57,6 +57,32 @@ class RawTimeStore {
     await prefs.setString(k, jsonEncode(list));
   }
 
+  static Future<void> editLast(RawTimeEntry newEntry) async {
+    final prefs = await SharedPreferences.getInstance();
+    final k = _key(newEntry.eventSlug);
+
+    final current = prefs.getString(k);
+    if (current == null) return;
+    final List<dynamic> list = jsonDecode(current) as List<dynamic>;
+    if (list.isEmpty) return;
+
+    list.last = newEntry.toJson();
+    await prefs.setString(k, jsonEncode(list));
+  }
+
+  static Future<void> removeLast(String eventSlug) async {
+    final prefs = await SharedPreferences.getInstance();
+    final k = _key(eventSlug);
+
+    final current = prefs.getString(k);
+    if (current == null) return;
+    final List<dynamic> list = jsonDecode(current) as List<dynamic>;
+    if (list.isEmpty) return;
+
+    list.removeLast();
+    await prefs.setString(k, jsonEncode(list));
+  }
+
   static Future<List<RawTimeEntry>> list(String eventSlug) async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_key(eventSlug));

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -3,8 +3,8 @@ class TimeUtils {
   /// Formats the current local time into a string with the format:
   /// "YYYY-MM-DD HH:MM:SS±HH:MM"
   /// Example: "2024-06-15 14:30:45+02:00"
-  static String formatEnteredTimeLocal() {
-    final now = DateTime.now();
+  static String formatEnteredTimeLocal([DateTime? dateTime]) {
+    final now = dateTime ?? DateTime.now();
     final y = now.year.toString().padLeft(4, '0');
     final mo = now.month.toString().padLeft(2, '0');
     final d = now.day.toString().padLeft(2, '0');

--- a/lib/widgets/live_entry_widgets/edit_bottom_sheet.dart
+++ b/lib/widgets/live_entry_widgets/edit_bottom_sheet.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:open_split_time_v2/widgets/live_entry_widgets/two_state_toggle.dart';
-import 'dart:developer' as developer;
+import 'package:open_split_time_v2/controllers/live_entry_controller.dart';
 
 class EditEntryBottomSheet extends StatefulWidget {
+  final LiveEntryController controller;
   final String eventName;
   final String bibNumber;
   final String athleteName;
@@ -14,6 +15,7 @@ class EditEntryBottomSheet extends StatefulWidget {
 
   const EditEntryBottomSheet({
     super.key,
+    required this.controller,
     required this.eventName,
     required this.bibNumber,
     required this.athleteName,
@@ -35,12 +37,14 @@ class _EditEntryBottomSheetState extends State<EditEntryBottomSheet> {
 
   bool isContinuing = false;
   bool hasPacer = false;
+  String currentAthleteName = '';
 
   @override
   void initState() {
     super.initState();
     isContinuing = widget.isContinuing;
     hasPacer = widget.hasPacer;
+    currentAthleteName = widget.athleteName;
     _bibController = TextEditingController(text: widget.bibNumber);
 
     // 1. Parse Date
@@ -233,13 +237,20 @@ class _EditEntryBottomSheetState extends State<EditEntryBottomSheet> {
                       border: OutlineInputBorder(),
                     ),
                     style: const TextStyle(fontSize: 16),
+                    onChanged: (value) {
+                      widget.controller.updateBibNumber(value);
+                      widget.controller.updateAthleteInfo();
+                      setState(() {
+                        currentAthleteName = widget.controller.athleteName;
+                      });
+                    },
                   ),
                 ),
               ],
             ),
             const SizedBox(height: 10),
 
-            _buildInfoRow('Bib Found:', widget.athleteName),
+            _buildInfoRow('Bib Found:', currentAthleteName),
 
             // --- Editable Date (Cupertino) ---
             Padding(
@@ -338,7 +349,7 @@ class _EditEntryBottomSheetState extends State<EditEntryBottomSheet> {
                     ),
                     onPressed: () {
                       // TODO: Delete Logic
-                      developer.log("Delete requested for bib ${_bibController.text}");
+                      widget.controller.deleteLastEntry();
                       Navigator.pop(context);
                     },
                     child: const Text('Delete'),
@@ -353,10 +364,20 @@ class _EditEntryBottomSheetState extends State<EditEntryBottomSheet> {
                     ),
                     onPressed: () {
                       // TODO: Update Logic
-                      developer.log("Update requested:");
-                      developer.log("Bib: ${_bibController.text}");
-                      developer.log("Date: $_formattedDate");
-                      developer.log("Time: $_formattedTime");
+                      final newDateTime = DateTime(
+                        _selectedDate.year,
+                        _selectedDate.month,
+                        _selectedDate.day,
+                        _selectedDuration.inHours,
+                        _selectedDuration.inMinutes % 60,
+                        _selectedDuration.inSeconds % 60,
+                      );
+                      widget.controller.editLastEntry(
+                        _bibController.text,
+                        newDateTime,
+                        isContinuing,
+                        hasPacer,
+                      );
                       Navigator.pop(context);
                     },
                     child: const Text('Update'),


### PR DESCRIPTION
This should make the edit box work finally. Also makes sure that no duplicate entries are created when this happens as apparently that was a bug introduced upon trying to use this menu.

Something to check later is implementing this for review sync as right now the way this box works is assuming the latest entry is the only one you can edit and making sure that it's json is edited when you make changes in the edit menu. However, obviously for the review sync page it could be any arbitrary entry so we'll need to figure that out in the next week or so.